### PR TITLE
	modified:   localassort.py

### DIFF
--- a/localassort.py
+++ b/localassort.py
@@ -136,7 +136,7 @@ def createA(E, n, m, undir=True):
         G = nx.DiGraph()
     G.add_nodes_from(range(n))
     G.add_edges_from(list(E))
-    A = nx.to_scipy_sparse_matrix(G)
+    A = nx.to_scipy_sparse_array(G)
 
     degree = np.array(A.sum(1)).flatten()
 


### PR DESCRIPTION
Hi, 

The function `to_scipy_sparse_matrix` (https://networkx.org/documentation/networkx-1.10/reference/generated/networkx.convert_matrix.to_scipy_sparse_matrix.html) has been deprecated in the latest version of NetworkX.

I updated it to the new function `to_scipy_sparse_array` (https://networkx.org/documentation/stable/reference/generated/networkx.convert_matrix.to_scipy_sparse_array.html).